### PR TITLE
fix a step to activate proper gpg agent behavior

### DIFF
--- a/_posts/2022-05-06-signed-git-commit.md
+++ b/_posts/2022-05-06-signed-git-commit.md
@@ -127,6 +127,7 @@ Mais bon, on va le configurer pour le faire à chaque commit.
 $ git config --global commit.gpgsign true
 $ git config --global gpg.program gpg
 $ git config --global user.signingkey ABCDEFGHIJKLMNOP
+$ killall gpg-agent
 ```
 
 Et voilà vos commits sont signés 😎.


### PR DESCRIPTION
if you don't restart the gpg agent, your git commit command won't be able to sign